### PR TITLE
[INFRA] Setup release-drafter for release notes inialization

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,43 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+prerelease: false
+categories:
+  - title: 🚀 Improvements
+    labels:
+      - enhancement
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+  - title: 📝 Documentation
+    label: documentation
+  - title: 👻 Maintenance
+    labels:
+      - infra:build
+      - infra:refactoring
+      - infra:repo
+      - chore
+      - internal
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
+exclude-labels:
+  - invalid
+  - no-changelog
+  - skip-changelog
+  - reverted
+  - wontfix
+template: |
+  **TODO: add a short description about the release content - important for url preview**
+  This new release focuses on .... **or something similar**
+
+
+  **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
+  Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
+
+
+  # Highlights
+
+  **TODO: add screenshots and user oriented info**
+
+  # What's Changed
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,14 +26,13 @@ exclude-labels:
   - skip-changelog
   - reverted
   - wontfix
+
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
 
-
   **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
   Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
-
 
   # Highlights
 
@@ -41,3 +40,4 @@ template: |
 
   # What's Changed
   $CHANGES
+

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
+    permissions:
+      # To create or update releases
+      # https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # TODO tmp to check gh_token permissions
+  pull_request:
+    branches:
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -1,0 +1,15 @@
+name: Fill GitHub Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  # TODO tmp to check gh_token permissions
-  pull_request:
-    branches:
-      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
⚠️ release-drafter cannot be tested through the PR, because the config file must be present in the default branch.
It will be tested using the [github-actions-playground repository](https://github.com/process-analytics/github-actions-playground)
See https://github.com/process-analytics/github-actions-playground/pull/29

closes #29