### PR TITLE
[FIX] Manage adding overlays referencing an unknown bpmn element

### DIFF
--- a/inst/htmlwidgets/bpmnVisualization.js
+++ b/inst/htmlwidgets/bpmnVisualization.js
@@ -29,7 +29,7 @@ HTMLWidgets.widget({
                 x.overlays && x.overlays.map(overlay => {
                     const elementsByIds = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(overlay.elementId);
 
-                    if (elementsByIds) {
+                    if (elementsByIds.length) {
                         const overlayConfig = elementsByIds[0].bpmnSemantic.isShape ? {
                             position: 'top-center',
                             label: overlay.label,


### PR DESCRIPTION
Previously, this generated an error preventing adding the rest of the overlays present in the array.

Fixes #44