### PR TITLE
[DOC] Improve examples rendering in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ library(bpmnVisualization)
 `bpmnVisualization` accepts a BPMN file (or an XML document):
 
 ```r
-bpmn_file <- system.file("examples/Email_Voting.bpmn", package = "bpmnVisualization") # File from the package
+# File from the package
+bpmn_file <- system.file("examples/Email_Voting.bpmn", package = "bpmnVisualization")
 ```
 
 Or
@@ -79,7 +80,8 @@ bpmnVisualization::display(bpmn_file)
 ### Display the BPMN diagram with overlays
 
 ```r
-overlays <- list(bpmnVisualization::create_overlay("bpmn_element_id_1", "42"), bpmnVisualization::create_overlay("bpmn_element_id_2", "9"))
+overlays <- list(bpmnVisualization::create_overlay("bpmn_element_id_1", "42"), 
+                 bpmnVisualization::create_overlay("bpmn_element_id_2", "9"))
 bpmnVisualization::display(bpmn_file, overlays)
 ```
 


### PR DESCRIPTION
Format the code to avoid displaying scrollbars (at least on GitHub)