### PR TITLE
[INFRA] Improve the release-notes generation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,7 @@ categories:
       - chore
       - internal
   - title: 📦 Dependency updates
+    collapse-after: 5
     labels:
       - dependencies
 exclude-labels:
@@ -26,7 +27,11 @@ exclude-labels:
   - skip-changelog
   - reverted
   - wontfix
-
+# Exclude specific usernames from the generated $CONTRIBUTORS variable.
+# https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
+exclude-contributors:
+  - 'dependabot'
+  - 'dependabot[bot]'
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**
@@ -44,3 +49,5 @@ template: |
   # What's Changed
   $CHANGES
 
+  **TODO: check previous and next tag in the link below**
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -1,6 +1,7 @@
 name: Fill GitHub Draft Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -14,6 +14,6 @@ jobs:
       contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`release-drafter` configuration
  - 'Dependencies' category: collapsed if more than 5 elements
  - exclude `dependabot` from the CONTRIBUTORS list. We removed it manually on every release so make it automatically
  - generate a link to the full changelog in the git history.

GitHub workflow
  - use a specific action version to better control updates and the use of new features. `dependabot` will create PR for action updates when new release-drafter releases are available
  - allow running release-drafter on demand. This is useful to fix the release notes after PR relabel

**Notes**
Replicate what we did in https://github.com/process-analytics/bpmn-visualization-js/pull/1759, https://github.com/process-analytics/bpmn-visualization-js/pull/1851 and https://github.com/process-analytics/bpmn-visualization-js/pull/1853