### PR TITLE
[EXAMPLE] Improve waypoints in the 'email voting' diagram

### DIFF
--- a/inst/examples/Email_Voting.bpmn
+++ b/inst/examples/Email_Voting.bpmn
@@ -690,7 +690,7 @@
                 </bpmndi:BPMNLabel>
             </bpmndi:BPMNEdge>
             <bpmndi:BPMNEdge id="Trisotech.Visio__6_sequence_flow_2" bpmnElement="sequence_flow_2">
-                <di:waypoint x="453" y="867"/>
+                <di:waypoint x="465" y="867"/>
                 <di:waypoint x="541" y="867"/>
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
@@ -869,7 +869,7 @@
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
             <bpmndi:BPMNEdge id="Trisotech.Visio__6_sequence_flow_48" bpmnElement="sequence_flow_48">
-                <di:waypoint x="2179" y="640"/>
+                <di:waypoint x="2206" y="640"/>
                 <di:waypoint x="2516" y="641"/>
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
@@ -938,7 +938,7 @@
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
             <bpmndi:BPMNEdge id="Trisotech.Visio__6_sequence_flow_37" bpmnElement="sequence_flow_37">
-                <di:waypoint x="2007" y="869"/>
+                <di:waypoint x="2017" y="869"/>
                 <di:waypoint x="2110" y="869"/>
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>

--- a/inst/examples/Email_Voting.bpmn
+++ b/inst/examples/Email_Voting.bpmn
@@ -1061,7 +1061,7 @@
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
             <bpmndi:BPMNEdge id="Trisotech.Visio__6_sequence_flow_35" bpmnElement="sequence_flow_35">
-                <di:waypoint x="1183" y="880"/>
+                <di:waypoint x="1200" y="880"/>
                 <di:waypoint x="1232" y="880"/>
                 <di:waypoint x="1232" y="939"/>
                 <bpmndi:BPMNLabel/>
@@ -1114,7 +1114,7 @@
                 <bpmndi:BPMNLabel/>
             </bpmndi:BPMNEdge>
             <bpmndi:BPMNEdge id="Trisotech.Visio__6_sequence_flow_26" bpmnElement="sequence_flow_26">
-                <di:waypoint x="792" y="873"/>
+                <di:waypoint x="792" y="883"/>
                 <di:waypoint x="792" y="1110"/>
                 <di:waypoint x="856" y="1110"/>
                 <bpmndi:BPMNLabel/>


### PR DESCRIPTION
Some terminal waypoints were defined inside the shapes. `bpmn-visualization@0.23.0` doesn't fix the rendering anymore: it is not putting them on the shape perimeter.
So fix the coordinates to make them appear on the perimeters.

This has been detected in https://github.com/process-analytics/bpmn-visualization-R/pull/65#pullrequestreview-924731140

before | now
------ | --------
![image](https://user-images.githubusercontent.com/27200110/160790526-d5bd110c-9498-4661-868c-9e48c6faccf7.png) | ![image](https://user-images.githubusercontent.com/27200110/160790283-582c71bf-5aa1-4dca-8f8c-c67a3ae1eab2.png)
