### PR TITLE
[DOC] Fix the documentation to better match CRAN requirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bpmnVisualization
 Type: Package
-Title: Visualize Process Execution Data on BPMN Diagrams
+Title: Visualize Process Execution Data on BPMN (Business Process Model and Notation) Diagrams
 Version: 0.2.1
 Authors@R: c(person("Celine", "Souchet", role = c("aut", "cre"), email = "process.analytics.dev+CRAN@gmail.com"),
              person("Thomas", "Bouffard", role = "aut"))

--- a/man/bpmnVisualization-package.Rd
+++ b/man/bpmnVisualization-package.Rd
@@ -20,7 +20,7 @@ The DESCRIPTION file:
 Maintainer: \packageMaintainer{bpmnVisualization}
 }
 \examples{
-\dontrun{
+\donttest{
 
 bpmnVisualization::display(bpmn_xml)
 

--- a/man/bpmnVisualization-package.Rd
+++ b/man/bpmnVisualization-package.Rd
@@ -19,23 +19,21 @@ The DESCRIPTION file:
 
 Maintainer: \packageMaintainer{bpmnVisualization}
 }
+
 \examples{
 \donttest{
+# Load the BPMN file
+bpmn_file <- system.file("examples/Order_Management.bpmn", package = "bpmnVisualization")
 
-bpmnVisualization::display(bpmn_xml)
-
+# Display the BPMN diagram
+display(bpmn_file, width='auto', height='auto')
 }
-
 }
 
 \section{More examples}{
-
-
   See \url{https://github.com/process-analytics/bpmn-visualization-R#readme} for more usage examples.
 }
 
 \section{Support}{
-
-
   Use \url{https://github.com/process-analytics/bpmn-visualization-R/issues} for bug reports
 }


### PR DESCRIPTION
The following updates are based on the last CRAN submission feedback:
  - DESCRIPTION: explain acronyms
  - bpmnVisualization-package.Rd
    - replace `\dontrun` with `\donttest`
    - update the example

covers #10 

### Last CRAN submission reject message

> Please always explain all acronyms in the description text. -> 'BPMN'
> 
> \dontrun{} should only be used if the example really cannot be executed (e.g. because of missing additional software, missing API keys, ...) by the user. That's why wrapping examples in \dontrun{} adds the comment ("# Not run:") as a warning for the user. Does not seem necessary. Please replace \dontrun with \donttest. -> bpmnVisualization-package.Rd
> 
> Please unwrap the examples if they are executable in < 5 sec, or replace dontrun{} with \donttest{}.
> 
> Please fix and resubmit.

