### PR TITLE
[DOC] Deploy Documentation to GitHub Pages

### DIFF
--- a/.github/actions/build-documentation-site/action.yml
+++ b/.github/actions/build-documentation-site/action.yml
@@ -1,0 +1,18 @@
+name: 'Build Documentation Site'
+description: 'Setup R and build the documentation'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: ./.github/actions/build-setup
+      with:
+        dependencies-extra-packages: any::pkgdown, local::.
+        dependencies-needs: website
+        r-version: release
+    - name: Build documentation website
+      if: github.event.action != 'closed'
+      shell: Rscript {0}
+      run: |
+        pkgdown::build_site()
+
+

--- a/.github/workflows/publish-documentation-pr-preview.yml
+++ b/.github/workflows/publish-documentation-pr-preview.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+    # keep in sync with publish-documentation-pr-preview
     paths:
       - '.github/actions/build-documentation-site/**/*'
       - '.github/actions/build-setup/**/*'

--- a/.github/workflows/publish-documentation-pr-preview.yml
+++ b/.github/workflows/publish-documentation-pr-preview.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   # for Pull Request
   pr_preview: # the id is used by surge to generate the surge url
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # surge-preview: PR comments

--- a/.github/workflows/publish-documentation-pr-preview.yml
+++ b/.github/workflows/publish-documentation-pr-preview.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/actions/build-documentation-site/**/*'
       - '.github/actions/build-setup/**/*'
       - '.github/workflows/publish-documentation-pr-preview.yml'
       - 'inst/**'
@@ -15,7 +16,7 @@ on:
       - '_pkgdown.yml'
       - 'CONTRIBUTING.md'
       - 'DESCRIPTION'
-      - 'README.md' # TODO use the right file, the repo from the repo cannot be included (wrong format, too much info)
+      - 'index.md'
 
 jobs:
   # for Pull Request
@@ -27,17 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
-      - uses: ./.github/actions/build-setup
+      - uses: ./.github/actions/build-documentation-site
         if: github.event.action != 'closed'
-        with:
-          dependencies-extra-packages: any::pkgdown, local::.
-          dependencies-needs: website
-          r-version: release
-      - name: Build documentation website
-        if: github.event.action != 'closed'
-        shell: Rscript {0}
-        run: |
-          pkgdown::build_site()
       # Always upload the website for local browsing and when it cannot be deployed to surge
       - name: Upload documentation
         if: github.event.action != 'closed'

--- a/.github/workflows/publish-documentation-pr-preview.yml
+++ b/.github/workflows/publish-documentation-pr-preview.yml
@@ -1,4 +1,4 @@
-name: Publish Documentation
+name: Publish Documentation PR preview
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
       - main
     paths:
       - '.github/actions/build-setup/**/*'
-      - '.github/workflows/publish-documentation.yml'
+      - '.github/workflows/publish-documentation-pr-preview.yml'
       - 'inst/**'
       - 'man/**'
       - '.Rbuildignore'

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '.github/actions/build-documentation-site/**/*'
       - '.github/actions/build-setup/**/*'
-      - '.github/workflows/publish-documentation-pr-preview.yml'
+      - '.github/workflows/publish-documentation.yml'
       - 'inst/**'
       - 'man/**'
       - '.Rbuildignore'

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -1,0 +1,70 @@
+# Deploy the documentation to GitHub Pages
+name: Publish documentation
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+# TODO temp, switch to main when ok
+    branches: ["19-publish_gh-pages"]
+#    branches: ["main"]
+# TODO duplication with PR preview
+    paths:
+      - '.github/actions/build-documentation-site/**/*'
+      - '.github/actions/build-setup/**/*'
+      - '.github/workflows/publish-documentation-pr-preview.yml'
+      - 'inst/**'
+      - 'man/**'
+      - '.Rbuildignore'
+      - '_pkgdown.yml'
+      - 'CONTRIBUTING.md'
+      - 'DESCRIPTION'
+      - 'index.md'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/actions/build-documentation-site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Path of the directory containing the static assets.
+          path: ./docs
+
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -19,15 +19,8 @@ on:
       - 'CONTRIBUTING.md'
       - 'DESCRIPTION'
       - 'index.md'
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -51,20 +44,17 @@ jobs:
 
 
   deploy:
+    needs: build
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          # Upload entire repository
-          path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -2,11 +2,8 @@
 name: Publish Documentation
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-# TODO temp, switch to main when ok
-    branches: ["19-publish_gh-pages"]
-#    branches: ["main"]
+    branches: ["main"]
     # keep in sync with publish-documentation-pr-preview
     paths:
       - '.github/actions/build-documentation-site/**/*'

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -7,7 +7,7 @@ on:
 # TODO temp, switch to main when ok
     branches: ["19-publish_gh-pages"]
 #    branches: ["main"]
-# TODO duplication with PR preview
+    # keep in sync with publish-documentation-pr-preview
     paths:
       - '.github/actions/build-documentation-site/**/*'
       - '.github/actions/build-setup/**/*'

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -1,5 +1,5 @@
 # Deploy the documentation to GitHub Pages
-name: Publish documentation
+name: Publish Documentation
 
 on:
   # Runs on pushes targeting the default branch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Celine", "Souchet", role = c("aut", "cre"), email = "proces
 Description: To visualize the execution data of the processes on BPMN (Business Process Model and Notation) diagrams, using overlays, style customization and interactions, with BPMN Visualization.
 License: Apache License (== 2)
 Copyright: Bonitasoft S.A.
-URL: https://github.com/process-analytics/bpmn-visualization-R
+URL: https://process-analytics.github.io/bpmn-visualization-R/, https://github.com/process-analytics/bpmn-visualization-R
 BugReports: https://github.com/process-analytics/bpmn-visualization-R/issues
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Use a GitHub workflow to deploy
Update the DESCRIPTION file to mention the `gh-pages` URL
Update the Release workflow: update the release version in the doc site as well (index.md)

closes  #19