### PR TITLE
[DOC] Warn users for releases not available on CRAN

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -95,9 +95,12 @@ ___
 **NOTES**:
 - CRAN publishing is `in-progress`, see [#10](https://github.com/process-analytics/bpmn-visualization-R/issues/10)
 
-⚠️⚠️ Decide whether to publish on CRAN ⚠️⚠️
+#### ⚠️⚠️ First decide whether to publish on CRAN ⚠️⚠️
+
 The CRAN policies state (see https://r-pkgs.org/release.html#cran-policies and https://cran.r-project.org/web/packages/policies.html)
 > Submitting updates should be done responsibly and with respect for the volunteers’ time. Once a package is established (which may take several rounds), “no more than every 1–2 months” seems appropriate. 
+
+However, on our side, we can provide more frequent versions. In this case, do not publish no CRAN. The new version will be available only via an installation from GitHub.
 
 #### Generate and retrieve the source package
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,7 +84,7 @@ ___
 - In the release description (check previous releases as a source of inspiration)
   - If the bpmn-visualization TypeScript library was updated, add a phrase about it (see [Release 0.2.1](https://github.com/process-analytics/bpmn-visualization-R/releases/tag/v0.2.1) for instance.): `The R package now uses [bpmn-visualization@0.26.2](https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.26.2).`
   - Put screenshots/gif of the new features.
-  - If the package won't be published to CRAN, please make it explicit by adding a sentence in bold! The sentence must explain why the is not published on CRAN and remind to install it using the GitHub way.
+  - If the package will not be published on CRAN (see below), please specify it by adding a sentence in bold! The sentence should explain why the new version is not available on CRAN and remind to install it using GitHub.
 - At any time, you can save the draft.
 - **Only when you are done**:
   - Assign the tag of the new version as release target and save the draft (doing it as later as possible ensure that `release-drafter` doesn't interfer with the writing of the Release Notes)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -83,7 +83,8 @@ ___
 - Open the draft release note in [GitHub releases](https://github.com/process-analytics/bpmn-visualization-R/releases)
 - In the release description (check previous releases as a source of inspiration)
   - If the bpmn-visualization TypeScript library was updated, add a phrase about it (see [Release 0.2.1](https://github.com/process-analytics/bpmn-visualization-R/releases/tag/v0.2.1) for instance.): `The R package now uses [bpmn-visualization@0.26.2](https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.26.2).`
-  - put screenshots/gif of the new features.
+  - Put screenshots/gif of the new features.
+  - If the package won't be published to CRAN, please make it explicit by adding a sentence in bold! The sentence must explain why the is not published on CRAN and remind to install it using the GitHub way.
 - At any time, you can save the draft.
 - **Only when you are done**:
   - Assign the tag of the new version as release target and save the draft (doing it as later as possible ensure that `release-drafter` doesn't interfer with the writing of the Release Notes)
@@ -93,6 +94,10 @@ ___
 
 **NOTES**:
 - CRAN publishing is `in-progress`, see [#10](https://github.com/process-analytics/bpmn-visualization-R/issues/10)
+
+⚠️⚠️ Decide whether to publish on CRAN ⚠️⚠️
+The CRAN policies state (see https://r-pkgs.org/release.html#cran-policies and https://cran.r-project.org/web/packages/policies.html)
+> Submitting updates should be done responsibly and with respect for the volunteers’ time. Once a package is established (which may take several rounds), “no more than every 1–2 months” seems appropriate. 
 
 #### Generate and retrieve the source package
 
@@ -116,10 +121,11 @@ It conforms to [the CRAN Submission policies first](https://cran.r-project.org/w
   - upload the package `tar.gz` source previously retrieved
   - for all required fields, use the value from the DESCRIPTION file of the `tar.gz` source (in particular, the name and email of the maintainer of the package are available at the end of the file)
 - Submit
+- **Don't forget to confirm the submission**: a few minutes after the submission, the package manager should have received an email asking to confirm the submission.
 
 ## Communicate about the release
 
-- Open [github actions](https://github.com/process-analytics/bpmn-visualization-R/actions/workflows/announce-new-release.yml)
+- Open [GitHub Actions](https://github.com/process-analytics/bpmn-visualization-R/actions/workflows/announce-new-release.yml)
 - Click on the 'Run workflow' dropdown located on the right side of the page
 - Provide parameter values for _version_ and _description_
 - Click on the button 'Run workflow'

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -124,7 +124,10 @@ It conforms to [the CRAN Submission policies first](https://cran.r-project.org/w
   - upload the package `tar.gz` source previously retrieved
   - for all required fields, use the value from the DESCRIPTION file of the `tar.gz` source (in particular, the name and email of the maintainer of the package are available at the end of the file)
 - Submit
-- **Don't forget to confirm the submission**: a few minutes after the submission, the package manager should have received an email asking to confirm the submission.
+- **Don't forget to confirm the submission**:
+  - A few minutes after the submission, the package manager should have received an email asking to confirm the submission. The email object looks like `CRAN Submission of bpmnVisualizationR 0.3.0 - Confirmation Link`
+  - Confirm the submission by clicking on the link provided in the email
+  - The submission is only effective when a new email is received from CRAN confirming the submission. The email object looks like `CRAN Submission of bpmnVisualizationR 0.3.0`
 
 ## Communicate about the release
 


### PR DESCRIPTION
Update the maintainers documentation to remind writers to notify users through the release notes. In this case, the new version of the package will be install using GitHub.

closes #159 