### PR TITLE
[INFRA] Fix the package renaming in the R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,14 +72,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-source-package
-          path: bpmnVisualization_*.tar.gz
+          path: bpmnVisualizationR_*.tar.gz
       - name: Check the source package
         id: source_package_checks
-        run: R CMD check --as-cran bpmnVisualization_*.tar.gz
+        run: R CMD check --as-cran bpmnVisualizationR_*.tar.gz
 
       - name: Upload source package check results
         if: ${{ failure() && steps.source_package_checks.outcome == 'failure' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-source-package-check-results
-          path: bpmnVisualization.Rcheck
+          path: bpmnVisualizationR.Rcheck


### PR DESCRIPTION
Some configuration changes were forgotten in the workflow at the time of the name change (from `bpmnVisualization` to `bpmnVisualizationR`).

### Before
![image](https://user-images.githubusercontent.com/4921914/211352334-75c54e88-ae0e-4c3e-9965-cb91d7689a44.png)


### Now
![image](https://user-images.githubusercontent.com/4921914/211352223-9f60c850-3820-4812-a4d1-5991f2e8ec44.png)
