### PR TITLE
chore: ensure that the PR title follows "Conventional Commits"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     open-pull-requests-limit: 2
     rebase-strategy: "disabled"
     commit-message:
-      prefix: "[INFRA] gha -"
+      prefix: "chore(gha)"
     labels:
       - dependencies
       - github_actions

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,14 @@
+name: Check Pull Request Metadata
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,11 @@ jobs:
           git add README.md
           git add cran-comments.md
           git add DESCRIPTION
-          git commit -m "[RELEASE] Set the release version to ${{ steps.release_version.outputs.version }}"
+          git commit -m "chore(release): set the release version to ${{ steps.release_version.outputs.version }}"
 
       - name: Tag ${{ steps.release_version.outputs.version }}
         run: |
-          git tag -a ${{ steps.release_version.outputs.version_tag }} -m "[RELEASE] ${{ steps.release_version.outputs.version }}"
+          git tag -a ${{ steps.release_version.outputs.version_tag }} -m "chore(release): ${{ steps.release_version.outputs.version }}"
 
       - name: Update with the development version
         run: |-
@@ -72,7 +72,7 @@ jobs:
       - name: Commit with the development version
         run: |
           git add DESCRIPTION
-          git commit -m "[RELEASE] Set the development version to ${{ steps.release_version.outputs.version }}.9000"
+          git commit -m "chore(release): set the development version to ${{ steps.release_version.outputs.version }}.9000"
 
       - name: Push commits and tags
         run: |

--- a/.github/workflows/update-bpmn-visualization-version.yml
+++ b/.github/workflows/update-bpmn-visualization-version.yml
@@ -35,13 +35,13 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN }}
-          commit-message: "[INFRA] Bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
+          commit-message: "chore(deps): bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
           committer: "process-analytics-bot <62586190+process-analytics-bot@users.noreply.github.com>"
           author: "process-analytics-bot <62586190+process-analytics-bot@users.noreply.github.com>"
-          branch: "infra/bump_bpmn_visualization_from_${{ env.OLD_VERSION }}_to_${{ env.VERSION }}"
+          branch: "chore/bump_bpmn_visualization_from_${{ env.OLD_VERSION }}_to_${{ env.VERSION }}"
           delete-branch: true
           base: "main"
-          title: "[INFRA] Bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
+          title: "chore(deps): bump bpmn-visualization from ${{ env.OLD_VERSION }} to ${{ env.VERSION }}"
           body: "bpmn-visualization is updated from https://cdn.jsdelivr.net/npm/bpmn-visualization@${{ env.VERSION }}/dist/bpmn-visualization.min.js."
           labels: "dependencies"
           team-reviewers: pa-collaborators

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -133,11 +133,11 @@ Check that the files are using the version to be released:
 - [README](./README.md)
 
 Create a new PR (it must have the `skip-changelog` label as we don't want it to appear in the release notes) and merge it,
-if some files require changes. The PR/commit message should be `[RELEASE] Set version to x.y.z`.
+if some files require changes. The PR/commit message should be `chore(release): set version to x.y.z`.
 
 Once this is done, tag manually with the following command (**do not forget** to replace `x.y.z` by the actual version):
 ``` 
-git tag -a vx.y.z -m "[RELEASE] x.y.z"
+git tag -a vx.y.z -m "chore(release): x.y.z"
 git push && git push --tags
 ```
 
@@ -147,7 +147,7 @@ Add the `.9000` suffix to the `Version` field in the [DESCRIPTION](./DESCRIPTION
 For instance, if the released version was `0.3.0`, the `Version` field in the `DESCRIPTION` file should be `0.3.O.9000`.
 
 Create a new PR (it must have the `skip-changelog` label as we don't want it to appear in the release notes) and merge it.
-The PR/commit message should be `[INFRA] Set the development version to x.y.z.9000`.
+The PR/commit message should be `chore(release): set the development version to x.y.z.9000`.
 
 ___
 


### PR DESCRIPTION
Related changes:
  - Add a dedicated workflow to enforce the rule. It runs on `pull_request_target` to handle PR created by Dependabot and from fork repositories.
  - Dependabot configuration: change PR title prefix.
  - Update the GitHub workflows that create commits and PR. They now follow "conventional commits".
  - Update the release process documentation.

closes #202

### Notes
For tests, see https://github.com/process-analytics/github-actions-playground/issues/213