### PR TITLE
docs: enabling markdown support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ URL: https://process-analytics.github.io/bpmn-visualization-R/, https://github.c
 BugReports: https://github.com/process-analytics/bpmn-visualization-R/issues/
 Encoding: UTF-8
 RoxygenNote: 7.2.3
+Roxygen: list(markdown = TRUE)
 Imports:
     htmlwidgets,
     rlang,

--- a/R/bpmnVisualizationR.R
+++ b/R/bpmnVisualizationR.R
@@ -21,7 +21,7 @@
 #' @param overlays An element or a list of elements to be added to the diagram's existing elements.
 #'      Use the [`create_overlay`] function to create an overlay object with content and a relative position.
 #' @param enableDefaultOverlayStyle If no style is set on an overlay, and this parameter is set to `TRUE`, the default style will be applied to the overlay.
-#'      By default, [`enableDefaultOverlayStyle`] is set to `TRUE`.
+#'      By default, `enableDefaultOverlayStyle` is set to `TRUE`.
 #' @param width A fixed width for the widget (in CSS units).
 #'      The default value is `NULL`, which results in intelligent automatic sizing based on the widget's container.
 #' @param height A fixed height for the widget (in CSS units).
@@ -162,8 +162,8 @@ bpmnVisualizationROutput <- function(
 #' Helper to create render function for using the `bpmnVisualizationR` 'HTML' widget within 'Shiny' applications and interactive 'Rmd' documents.
 #'
 #' @param expr An expression that generates a `bpmnVisualizationR` 'HTML' widget
-#' @param env The environment in which to evaluate [`expr`].
-#' @param quoted Is [`expr`] a quoted expression (with \code{quote()})? This
+#' @param env The environment in which to evaluate `expr`.
+#' @param quoted Is `expr` a quoted expression (with `quote()`)? This
 #'   is useful if you want to save an expression in a variable.
 #'
 #' @returns A render function that enables the use of the `bpmnVisualizationR` widget within 'Shiny' applications.

--- a/R/bpmnVisualizationR.R
+++ b/R/bpmnVisualizationR.R
@@ -19,19 +19,19 @@
 #'
 #' @param bpmnXML A file name or 'XML' document or string in 'BPMN' 'XML' format
 #' @param overlays An element or a list of elements to be added to the diagram's existing elements.
-#'      Use the \code{create_overlay} function to create an overlay object with content and a relative position.
-#' @param enableDefaultOverlayStyle If no style is set on an overlay, and this parameter is set to \code{TRUE}, the default style will be applied to the overlay.
-#'      By default, \code{enableDefaultOverlayStyle} is set to \code{TRUE}.
+#'      Use the [`create_overlay`] function to create an overlay object with content and a relative position.
+#' @param enableDefaultOverlayStyle If no style is set on an overlay, and this parameter is set to `TRUE`, the default style will be applied to the overlay.
+#'      By default, [`enableDefaultOverlayStyle`] is set to `TRUE`.
 #' @param width A fixed width for the widget (in CSS units).
-#'      The default value is \code{NULL}, which results in intelligent automatic sizing based on the widget's container.
+#'      The default value is `NULL`, which results in intelligent automatic sizing based on the widget's container.
 #' @param height A fixed height for the widget (in CSS units).
-#'      The default value is \code{NULL}, which results in intelligent automatic sizing based on the widget's container.
+#'      The default value is `NULL`, which results in intelligent automatic sizing based on the widget's container.
 #' @param elementId The ID of the 'HTML' element to enclose the widget.
 #'      Use an explicit element ID for the widget (rather than an automatically generated one).
 #'      This is useful if you have other 'JavaScript' that needs to explicitly
 #'      discover and interact with a specific widget instance.
 #'
-#' @returns A \code{bpmnVisualizationR} widget that will intelligently print itself into 'HTML' in a variety of contexts
+#' @returns A `bpmnVisualizationR` widget that will intelligently print itself into 'HTML' in a variety of contexts
 #'      including the 'R' console, within 'R Markdown' documents, and within 'Shiny' output bindings.
 #'
 #' @examples
@@ -98,7 +98,7 @@
 #'   height='auto'
 #' )
 #'
-#' @seealso \code{\link{create_overlay}} to create an overlay
+#' @seealso [`create_overlay`] to create an overlay
 #'
 #' @import htmlwidgets
 #' @import xml2
@@ -128,18 +128,17 @@ display <- function(
   )
 }
 
-#' @title Shiny output binding for the \code{bpmnVisualizationR} 'HTML' widget
+#' @title Shiny output binding for the `bpmnVisualizationR` 'HTML' widget
 #'
 #' @name bpmnVisualizationR-shiny-output
 #' @description
-#' Helper to create output function for using the \code{bpmnVisualizationR} 'HTML' widget within 'Shiny' applications and interactive 'Rmd' documents.
+#' Helper to create output function for using the `bpmnVisualizationR` 'HTML' widget within 'Shiny' applications and interactive 'Rmd' documents.
 #'
 #' @param outputId output variable to read from
-#' @param width,height Must be a valid CSS unit (like \code{'100\%'},
-#'   \code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
-#'   string and have \code{'px'} appended.
+#' @param width,height Must be a valid CSS unit (like `100%`, `400px`, `auto`) or a number,
+#'  which will be coerced to a string and have `px` appended.
 #'
-#' @returns An output function that enables the use of the \code{bpmnVisualizationR} widget within 'Shiny' applications.
+#' @returns An output function that enables the use of the `bpmnVisualizationR` widget within 'Shiny' applications.
 #'
 #' @export
 bpmnVisualizationROutput <- function(
@@ -156,18 +155,18 @@ bpmnVisualizationROutput <- function(
   )
 }
 
-#' @title 'Shiny' render binding for the \code{bpmnVisualizationR} 'HTML' widget
+#' @title 'Shiny' render binding for the `bpmnVisualizationR` 'HTML' widget
 #'
 #' @rdname bpmnVisualizationR-shiny-render
 #' @description
-#' Helper to create render function for using the \code{bpmnVisualizationR} 'HTML' widget within 'Shiny' applications and interactive 'Rmd' documents.
+#' Helper to create render function for using the `bpmnVisualizationR` 'HTML' widget within 'Shiny' applications and interactive 'Rmd' documents.
 #'
-#' @param expr An expression that generates a \code{bpmnVisualizationR} 'HTML' widget
-#' @param env The environment in which to evaluate \code{expr}.
-#' @param quoted Is \code{expr} a quoted expression (with \code{quote()})? This
+#' @param expr An expression that generates a `bpmnVisualizationR` 'HTML' widget
+#' @param env The environment in which to evaluate [`expr`].
+#' @param quoted Is [`expr`] a quoted expression (with \code{quote()})? This
 #'   is useful if you want to save an expression in a variable.
 #'
-#' @returns A render function that enables the use of the \code{bpmnVisualizationR} widget within 'Shiny' applications.
+#' @returns A render function that enables the use of the `bpmnVisualizationR` widget within 'Shiny' applications.
 #'
 #' @export
 renderBpmnVisualizationR <- function(

--- a/R/funs.R
+++ b/R/funs.R
@@ -1,25 +1,22 @@
-#' @title The overlay positions on \code{Shape}
+#' @title The overlay positions on `Shape`
 #'
 #' @description
-#' To specify the position when creating an overlay object that will be attached to BPMN \code{Shape} elements in the diagram.
+#' To specify the position when creating an overlay object that will be attached to BPMN `Shape` elements in the diagram.
 #'
 #' @details
-#' Use these constants as the \code{position} argument in the \code{\link{create_overlay}} function.
+#' Use these constants as the `position` argument in the [`create_overlay`] function.
 #'
-#' @section Positions:
-#'  \itemize{
-#'    \item{\code{top-left}}{}
-#'    \item{\code{top-right}}{}
-#'    \item{\code{top-center}}{}
-#'    \item{\code{bottom-left}}{}
-#'    \item{\code{bottom-right}}{}
-#'    \item{\code{bottom-center}}{}
-#'    \item{\code{middle-left}}{}
-#'    \item{\code{middle-right}}{}
-#'  }
-#'  
-#' @seealso
-#' \code{\link{create_overlay}}
+#' **Positions**:
+#'  * `top-left`
+#'  * `top-right`
+#'  * `top-center`
+#'  * `bottom-left`
+#'  * `bottom-right`
+#'  * `bottom-center`
+#'  * `middle-left`
+#'  * `middle-right`
+#'
+#' @seealso [`create_overlay`]
 #' 
 #' @examples
 #' # Create an overlay at the top-left corner of a shape
@@ -38,23 +35,20 @@ overlay_shape_position <-
     "middle-right"
   )
 
-#' @title The overlay positions on \code{Edge}
+#' @title The overlay positions on `Edge`
 #'
 #' @description
-#' To specify the position when creating an overlay object that will be attached to BPMN \code{Edge} elements in the diagram.
+#' To specify the position when creating an overlay object that will be attached to BPMN `Edge` elements in the diagram.
 #' 
 #' @details
-#' Use these constants as the \code{position} argument in the \code{\link{create_overlay}} function.
+#' Use these constants as the `position` argument in the [`create_overlay`] function.
 #'
-#' @section Positions:
-#'  \itemize{
-#'    \item{\code{start}}{}
-#'    \item{\code{end}}{}
-#'    \item{\code{middle}}{}
-#'  }
+#' **Positions**:
+#'  * `start`
+#'  * `end`
+#'  * `middle`
 #'
-#' @seealso
-#' \code{\link{create_overlay}}
+#' @seealso [`create_overlay`]
 #'
 #' @examples
 #' # Create an overlay at the starting point of an edge
@@ -69,17 +63,17 @@ overlay_edge_position <- c("start", "end", "middle")
 #' @description 
 #' An overlay can be added to existing elements in the diagram.
 #' 
-#' See the \code{overlays} argument in the \code{\link{display}} function.
+#' See the `overlays` argument in the [`display`] function.
 #' 
 #' Use this function to create the correct overlay structure.
 #' 
 #' @param elementId The bpmn element id to which the overlay will be attached
 #' @param label 'HTML' element to use as an overlay
 #' @param style The style of the overlay.
-#'      Use \code{\link{create_overlay_style}} function to create the style object of an overlay and be aware of the `enableDefaultOverlayStyle` parameter in the \code{\link{display}} function.
+#'      Use [`create_overlay_style`] function to create the style object of an overlay and be aware of the `enableDefaultOverlayStyle` parameter in the [`display`] function.
 #' @param position The position of the overlay
-#'      If the bpmn element where the overlay will be attached is a Shape, use \code{\link{overlay_shape_position}}.
-#'      Otherwise, use \code{\link{overlay_edge_position}}.
+#'      If the bpmn element where the overlay will be attached is a Shape, use [`overlay_shape_position`].
+#'      Otherwise, use [`overlay_edge_position`].
 #'
 #' @returns An overlay object
 #'
@@ -141,17 +135,17 @@ create_overlay <- function(elementId, label, style = NULL, position = NULL) {
 #' @description
 #' When adding an overlay to an existing element in a diagram, it's possible to customize its style.
 #'
-#' Refer to the \code{style} parameter in the \code{\link{create_overlay}} function for more information.
+#' Refer to the `style` parameter in the [`create_overlay`] function for more information.
 #'
 #' Use this function to create the correct style structure for an overlay.
 #'
-#' @param font_color The font color of the overlay. Use all HTML color names or HEX codes.
+#' @param font_color The font color of the overlay. It can be any HTML color name or HEX code.
 #' @param font_size The font size of the overlay. Specify a number in px.
-#' @param fill_color The color of the background of the overlay. Use all HTML color names or HEX codes.
-#' @param stroke_color The color of the stroke of the overlay. Use all HTML color names or HEX codes.
-#'      If you don't want to display a stroke, you can set the color to:
-#'      - \code{transparent},
-#'      - the same value as for the \code{fill_color}. This increases the \code{padding}/\code{margin}.
+#' @param fill_color The color of the background of the overlay. It can be any HTML color name or HEX code.
+#' @param stroke_color The color of the stroke of the overlay. It can be any HTML color name or HEX code.\cr
+#' If you don't want to display a stroke, you can set the color to:
+#' * `transparent`,
+#' * the same value as for the `fill_color`. This increases the `padding`/`margin`.
 #'
 #' @returns The style object of the overlay
 #'
@@ -174,7 +168,7 @@ create_overlay_style <- function(font_color = NULL,
 #' @description
 #' - Overlay:
 #'  When adding an overlay to an existing element in a diagram, it's possible to customize its font style.
-#'  Refer to the \code{font} parameter in the \code{\link{create_overlay_style}} function for more information.
+#'  Refer to the `font` parameter in the [`create_overlay_style`] function for more information.
 #'  Use this function to create the correct font structure for an overlay.
 #'
 #' @param color The color of the font of the overlay
@@ -197,7 +191,7 @@ create_font <- function(color = NULL, size = NULL) {
 #' @description
 #' - Overlay:
 #'  When adding an overlay to an existing element in a diagram, it's possible to customize how it is filled.
-#'  Refer to the \code{fill} parameter in the \code{\link{create_overlay_style}} function for more information.
+#'  Refer to the `fill` parameter in the [`create_overlay_style`] function for more information.
 #'  Use this function to create the correct fill structure for an overlay.
 #'
 #' @param color The color of the background of the overlay
@@ -217,8 +211,8 @@ create_fill <- function(color) {
 #' @name create_stroke
 #' @description
 #' - Overlay:
-#'  When adding an overlay to an existing element in a diagram, it's possible to customize its stroke. style.
-#'  Refer to the \code{stroke.} parameter in the \code{\link{create_overlay_style}} function for more information.
+#'  When adding an overlay to an existing element in a diagram, it's possible to customize its stroke style.
+#'  Refer to the `stroke` parameter in the [`create_overlay_style`] function for more information.
 #'  Use this function to create the correct stroke structure for an overlay.
 #'
 #' @param color The color of the stroke of the overlay

--- a/man/bpmnVisualizationR-shiny-output.Rd
+++ b/man/bpmnVisualizationR-shiny-output.Rd
@@ -10,9 +10,8 @@ bpmnVisualizationROutput(outputId, width = "100\%", height = "400px")
 \arguments{
 \item{outputId}{output variable to read from}
 
-\item{width, height}{Must be a valid CSS unit (like \code{'100\%'},
-\code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
-string and have \code{'px'} appended.}
+\item{width, height}{Must be a valid CSS unit (like \verb{100\%}, \verb{400px}, \code{auto}) or a number,
+which will be coerced to a string and have \code{px} appended.}
 }
 \value{
 An output function that enables the use of the \code{bpmnVisualizationR} widget within 'Shiny' applications.

--- a/man/bpmnVisualizationR-shiny-render.Rd
+++ b/man/bpmnVisualizationR-shiny-render.Rd
@@ -9,9 +9,9 @@ renderBpmnVisualizationR(expr, env = parent.frame(), quoted = FALSE)
 \arguments{
 \item{expr}{An expression that generates a \code{bpmnVisualizationR} 'HTML' widget}
 
-\item{env}{The environment in which to evaluate \code{expr}.}
+\item{env}{The environment in which to evaluate \code{\link{expr}}.}
 
-\item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
+\item{quoted}{Is \code{\link{expr}} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 }
 \value{

--- a/man/bpmnVisualizationR-shiny-render.Rd
+++ b/man/bpmnVisualizationR-shiny-render.Rd
@@ -9,9 +9,9 @@ renderBpmnVisualizationR(expr, env = parent.frame(), quoted = FALSE)
 \arguments{
 \item{expr}{An expression that generates a \code{bpmnVisualizationR} 'HTML' widget}
 
-\item{env}{The environment in which to evaluate \code{\link{expr}}.}
+\item{env}{The environment in which to evaluate \code{expr}.}
 
-\item{quoted}{Is \code{\link{expr}} a quoted expression (with \code{quote()})? This
+\item{quoted}{Is \code{expr} a quoted expression (with \code{quote()})? This
 is useful if you want to save an expression in a variable.}
 }
 \value{

--- a/man/create_overlay.Rd
+++ b/man/create_overlay.Rd
@@ -12,7 +12,7 @@ create_overlay(elementId, label, style = NULL, position = NULL)
 \item{label}{'HTML' element to use as an overlay}
 
 \item{style}{The style of the overlay.
-Use \code{\link{create_overlay_style}} function to create the style object of an overlay and be aware of the `enableDefaultOverlayStyle` parameter in the \code{\link{display}} function.}
+Use \code{\link{create_overlay_style}} function to create the style object of an overlay and be aware of the \code{enableDefaultOverlayStyle} parameter in the \code{\link{display}} function.}
 
 \item{position}{The position of the overlay
 If the bpmn element where the overlay will be attached is a Shape, use \code{\link{overlay_shape_position}}.

--- a/man/create_overlay_style.Rd
+++ b/man/create_overlay_style.Rd
@@ -12,16 +12,18 @@ create_overlay_style(
 )
 }
 \arguments{
-\item{font_color}{The font color of the overlay. Use all HTML color names or HEX codes.}
+\item{font_color}{The font color of the overlay. It can be any HTML color name or HEX code.}
 
 \item{font_size}{The font size of the overlay. Specify a number in px.}
 
-\item{fill_color}{The color of the background of the overlay. Use all HTML color names or HEX codes.}
+\item{fill_color}{The color of the background of the overlay. It can be any HTML color name or HEX code.}
 
-\item{stroke_color}{The color of the stroke of the overlay. Use all HTML color names or HEX codes.
+\item{stroke_color}{The color of the stroke of the overlay. It can be any HTML color name or HEX code.\cr
 If you don't want to display a stroke, you can set the color to:
-- \code{transparent},
-- the same value as for the \code{fill_color}. This increases the \code{padding}/\code{margin}.}
+\itemize{
+\item \code{transparent},
+\item the same value as for the \code{fill_color}. This increases the \code{padding}/\code{margin}.
+}}
 }
 \value{
 The style object of the overlay

--- a/man/display.Rd
+++ b/man/display.Rd
@@ -17,10 +17,10 @@ display(
 \item{bpmnXML}{A file name or 'XML' document or string in 'BPMN' 'XML' format}
 
 \item{overlays}{An element or a list of elements to be added to the diagram's existing elements.
-Use the \code{create_overlay} function to create an overlay object with content and a relative position.}
+Use the \code{\link{create_overlay}} function to create an overlay object with content and a relative position.}
 
 \item{enableDefaultOverlayStyle}{If no style is set on an overlay, and this parameter is set to \code{TRUE}, the default style will be applied to the overlay.
-By default, \code{enableDefaultOverlayStyle} is set to \code{TRUE}.}
+By default, \code{\link{enableDefaultOverlayStyle}} is set to \code{TRUE}.}
 
 \item{width}{A fixed width for the widget (in CSS units).
 The default value is \code{NULL}, which results in intelligent automatic sizing based on the widget's container.}
@@ -35,7 +35,7 @@ discover and interact with a specific widget instance.}
 }
 \value{
 A \code{bpmnVisualizationR} widget that will intelligently print itself into 'HTML' in a variety of contexts
-     including the 'R' console, within 'R Markdown' documents, and within 'Shiny' output bindings.
+including the 'R' console, within 'R Markdown' documents, and within 'Shiny' output bindings.
 }
 \description{
 Display 'BPMN' diagram based on 'BPMN' definition in 'XML' format

--- a/man/display.Rd
+++ b/man/display.Rd
@@ -20,7 +20,7 @@ display(
 Use the \code{\link{create_overlay}} function to create an overlay object with content and a relative position.}
 
 \item{enableDefaultOverlayStyle}{If no style is set on an overlay, and this parameter is set to \code{TRUE}, the default style will be applied to the overlay.
-By default, \code{\link{enableDefaultOverlayStyle}} is set to \code{TRUE}.}
+By default, \code{enableDefaultOverlayStyle} is set to \code{TRUE}.}
 
 \item{width}{A fixed width for the widget (in CSS units).
 The default value is \code{NULL}, which results in intelligent automatic sizing based on the widget's container.}

--- a/man/overlay_edge_position.Rd
+++ b/man/overlay_edge_position.Rd
@@ -15,16 +15,14 @@ To specify the position when creating an overlay object that will be attached to
 }
 \details{
 Use these constants as the \code{position} argument in the \code{\link{create_overlay}} function.
-}
-\section{Positions}{
 
- \itemize{
-   \item{\code{start}}{}
-   \item{\code{end}}{}
-   \item{\code{middle}}{}
- }
+\strong{Positions}:
+\itemize{
+\item \code{start}
+\item \code{end}
+\item \code{middle}
 }
-
+}
 \examples{
 # Create an overlay at the starting point of an edge
 overlay <- create_overlay(elementId = 1, label = "My label", position = overlay_edge_position[1])

--- a/man/overlay_shape_position.Rd
+++ b/man/overlay_shape_position.Rd
@@ -15,21 +15,19 @@ To specify the position when creating an overlay object that will be attached to
 }
 \details{
 Use these constants as the \code{position} argument in the \code{\link{create_overlay}} function.
-}
-\section{Positions}{
 
- \itemize{
-   \item{\code{top-left}}{}
-   \item{\code{top-right}}{}
-   \item{\code{top-center}}{}
-   \item{\code{bottom-left}}{}
-   \item{\code{bottom-right}}{}
-   \item{\code{bottom-center}}{}
-   \item{\code{middle-left}}{}
-   \item{\code{middle-right}}{}
- }
+\strong{Positions}:
+\itemize{
+\item \code{top-left}
+\item \code{top-right}
+\item \code{top-center}
+\item \code{bottom-left}
+\item \code{bottom-right}
+\item \code{bottom-center}
+\item \code{middle-left}
+\item \code{middle-right}
 }
-
+}
 \examples{
 # Create an overlay at the top-left corner of a shape
 overlay <- create_overlay(elementId = 1, label = "My label", position = overlay_shape_position[1])


### PR DESCRIPTION
To simplify the writing and the reading of the documentation of #13, I enabled the markdown support.  
  
https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html