### PR TITLE
refactor: simplify overlay management in JS bridge code

### DIFF
--- a/inst/htmlwidgets/bpmnVisualizationR.js
+++ b/inst/htmlwidgets/bpmnVisualizationR.js
@@ -64,9 +64,9 @@ HTMLWidgets.widget({
                     const overlayConfig = {...rest};
                     
                     if(enableDefaultOverlayStyle && !(overlayConfig.style && overlayConfig.position)) {
-                        const elementsByIds = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(elementId);
-                        if (elementsByIds.length) {
-                            const isShape = elementsByIds[0].bpmnSemantic.isShape;
+                        const elements = bpmnVisualization.bpmnElementsRegistry.getModelElementsByIds(elementId);
+                        if (elements.length) {
+                            const isShape = elements[0].isShape;
                             overlayConfig.style ??= buildDefaultOverlayStyle(isShape);
                             overlayConfig.position ??= buildDefaultOverlayPosition(isShape);
                         }
@@ -80,7 +80,7 @@ HTMLWidgets.widget({
             },
 
             // Make the bpmnVisualization object available as a property on the widget instance we're returning from factory().
-            // This is generally a good idea for extensibility--it helps users of this widget interact directly with bpmnVisualization, if needed.
+            // This is generally a good idea for extensibility: it helps users of this widget to interact directly with bpmnVisualization, if required.
             s: bpmnVisualization
         };
     }


### PR DESCRIPTION
Call the new `BpmnElementsRegistry.getModelElementsByIds` method introduced in bpmn-visualization@0.39.0.

### Notes

- Detected in https://github.com/process-analytics/bpmn-visualization-R/pull/247/files/be77a8dc61ae0152401d90d82a6043907e2af925#r1324022400
- The surge preview can be used to validate the changes: the documentation of the `display` R function call the JavaScript code that manages overlays.
- Introduction of the new method: https://github.com/process-analytics/bpmn-visualization-js/releases/tag/v0.39.0