### PR TITLE
ci(release): eliminate bypassing of branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,12 @@ jobs:
       - run: |
           echo "New version type: ${{ github.event.inputs.type }}"
 
-      - name: Branch Protection Bot - Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: false
-          branch: main
-
       - name: Setup checkout
         uses: actions/checkout@v4
         with:
+          # Use a PAT to ensure that
+          #   commits are authored with a specific user
+          #   workflow run are triggered after git push
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
       - name: Config git
@@ -78,13 +73,6 @@ jobs:
         run: |
           git push && git push --tags
 
-      - name: Branch Protection Bot - Reenable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.9
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.GH_RELEASE_TOKEN }}
-          enforce_admins: true
-          branch: main
       - name: Send message to Slack channel
         if: success()
         uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
The workflow commits to the main branch and the branch protection configured in the GitHub repository prevents this for all users.

Previously, the protection was temporarily bypassed and the user performing the commit required administrator permissions (due to the configuration of the branch protection).

Now protection is done using GitHub branch ruleset, and there's no need to bypass protection. In this way, workflow can be simplified.

### Notes

The settings have already been updated
- ruleset replaces branch protection: https://github.com/process-analytics/bpmn-visualization-R/rules (publicly visible)
repository
- permissions of the user performing the Git operations in the repository has been downgraded. ⚠️ **IMPORTANT**: this PR must then be merged prior doing the next release. The workflow currently in the main branch requires this user to have more permissions. If executed, it will fail.

This configuration is already used in the `bv-experimental-add-ons` repository:
- https://github.com/process-analytics/bv-experimental-add-ons/blob/v0.4.0/.github/workflows/release.yml
- https://github.com/process-analytics/bv-experimental-add-ons/rules

![image](https://github.com/process-analytics/bpmn-visualization-R/assets/27200110/1a88c024-b92f-47a2-a1b5-b18a5c300972)
_Ruleset definition view as an non authenticated user_